### PR TITLE
[512384] Made Regular Expression to separate bundle name and version inside a jar file name more robust.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,7 @@
+image: maven:3-jdk-7
+before_script:
+  - apt-get update -qq && apt-get install -y -qq xvfb
+  - Xvfb :1 -screen 0 1024x768x24 -noreset +extension RANDR &
+  - export DISPLAY=:1
+build:
+  script: "mvn -version; cd maven; mvn clean install -U -fae -Dtycho.localArtifacts=ignore -f org.eclipse.emf.mwe2.parent/pom.xml"

--- a/maven/org.eclipse.emf.mwe2.target/org.eclipse.emf.mwe2.target.target
+++ b/maven/org.eclipse.emf.mwe2.target/org.eclipse.emf.mwe2.target.target
@@ -7,7 +7,7 @@
 <unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
-<repository location="http://download.eclipse.org/releases/helios/201102250900/"/>
+<repository location="http://download.eclipse.org/releases/juno/201303010900/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
 <unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
@@ -16,7 +16,7 @@
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
 <unit id="org.eclipse.xtext.ui.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.xtext.junit4" version="0.0.0"/>
-<repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/nightly/"/>
+<repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.10.0/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
 <unit id="org.eclipse.license.feature.group" version="0.0.0"/>

--- a/plugins/org.eclipse.emf.mwe.utils/src/org/eclipse/emf/mwe/utils/StandaloneSetup.java
+++ b/plugins/org.eclipse.emf.mwe.utils/src/org/eclipse/emf/mwe/utils/StandaloneSetup.java
@@ -358,13 +358,17 @@ public class StandaloneSetup {
 		return null;
 	}
 	
-	protected static final Pattern JAR_NAME_PATTERN = Pattern.compile("(.*?)(-.*)?\\.jar");
+	protected static final Pattern JAR_NAME_PATTERN = Pattern.compile("(?:(.*)(?:-v?\\d+(?:\\.\\d+)*.*)(?:\\.jar))|(?:(.*)(?:\\.jar))");
 	
 	protected String getBundleNameFromJarName(String jarFileName) {
 		File file = new File(jarFileName);
 		Matcher matcher = JAR_NAME_PATTERN.matcher(file.getName());
 		if (matcher.matches()) {
-			return matcher.group(1);
+			String g1 = matcher.group(1);
+			if (g1 != null) {
+				return g1;
+			}
+			return matcher.group(2);
 		}
 		return null;
 	}

--- a/tests/org.eclipse.emf.mwe.tests/runtime-tests/org/eclipse/emf/mwe/tests/util/Bug484372Test.java
+++ b/tests/org.eclipse.emf.mwe.tests/runtime-tests/org/eclipse/emf/mwe/tests/util/Bug484372Test.java
@@ -107,10 +107,9 @@ public class Bug484372Test extends Assert {
 				standaloneSetup.getBundleNameFromJarName("org.eclipse.xtext-v2015252525.jar"));
 		assertEquals("junit", standaloneSetup.getBundleNameFromJarName("junit.jar"));
 
-		//TODO fix this?
-		assertEquals("ant", standaloneSetup.getBundleNameFromJarName("ant-antlr.jar"));
-		assertEquals("apache", standaloneSetup.getBundleNameFromJarName("apache-commons-lang3.jar"));
-		assertEquals("apache", standaloneSetup.getBundleNameFromJarName("apache-commons-lang3-3.2.1.jar"));
+		assertEquals("ant-antlr", standaloneSetup.getBundleNameFromJarName("ant-antlr.jar"));
+		assertEquals("apache-commons-lang3", standaloneSetup.getBundleNameFromJarName("apache-commons-lang3.jar"));
+		assertEquals("apache-commons-lang3", standaloneSetup.getBundleNameFromJarName("apache-commons-lang3-3.2.1.jar"));
 
 	}
 


### PR DESCRIPTION
[512384] Made Regular Expression to separate bundle name and version inside a jar file name more robust.

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>