### PR TITLE
[releng] Activation cbi-sign profile depending on sign.skip prop

### DIFF
--- a/maven/org.eclipse.emf.mwe2.parent/pom.xml
+++ b/maven/org.eclipse.emf.mwe2.parent/pom.xml
@@ -245,8 +245,10 @@
 		<profile>
 			<id>cbi-sign</id>
 			<activation>
-				<activeByDefault>true</activeByDefault>
-				<!-- TODO move cbi signing plugin to this profile <property> <name>sign.skip</name> <value>false</value> </property> -->
+				<property>
+					<name>sign.skip</name>
+					<value>false</value>
+				</property>
 			</activation>
 			<pluginRepositories>
 				<pluginRepository>


### PR DESCRIPTION
The cbi-sign profile is activated when property 'sign.skip' is false.

Fixes #84 

Change-Id: I52b5053bc9e2feb28b902c11692410218a6a3c3e
Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>