### PR TITLE
[releng] Make disabling of Tycho version check conigurable 

### DIFF
--- a/maven/org.eclipse.emf.mwe2.parent/pom.xml
+++ b/maven/org.eclipse.emf.mwe2.parent/pom.xml
@@ -78,14 +78,6 @@
 			</plugin>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-packaging-plugin</artifactId>
-				<version>${tycho-version}</version>
-				<configuration>
-					<format>${tycho-qualifier}</format>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>target-platform-configuration</artifactId>
 				<version>${tycho-version}</version>
 				<configuration>
@@ -209,6 +201,15 @@
 						<excludeInnerJars>true</excludeInnerJars>
 					</configuration>
 				</plugin>
+				<plugin>
+					<groupId>org.eclipse.tycho</groupId>
+					<artifactId>tycho-packaging-plugin</artifactId>
+					<version>${tycho-version}</version>
+					<configuration>
+						<format>${tycho-qualifier}</format>
+						<strictVersions>true</strictVersions>
+					</configuration>
+				</plugin>
 				<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself. -->
 				<plugin>
 					<groupId>org.eclipse.m2e</groupId>
@@ -260,6 +261,33 @@
 					</snapshots>
 				</pluginRepository>
 			</pluginRepositories>
+		</profile>
+		<!-- 
+			Profile 'release' is activated when property BUILD_TYPE is NOT 'N' (nightly).
+			For release builds strict version checking is disabled, since Maven version will be a
+			release version, while OSGi artifacts (MANIFEST.MF, feature.xml) still contain a qualified version.
+		-->
+		<profile>
+			<id>release</id>
+			<activation>
+				<property>
+					<name>BUILD_TYPE</name>
+					<value>!N</value>
+				</property>
+			</activation>
+			<build>
+				<pluginManagement>
+					<plugins>
+						<plugin>
+							<groupId>org.eclipse.tycho</groupId>
+							<artifactId>tycho-packaging-plugin</artifactId>
+							<configuration>
+								<strictVersions>false</strictVersions>
+							</configuration>
+						</plugin>
+					</plugins>
+				</pluginManagement>
+			</build>
 		</profile>
 	</profiles>
 	<scm>

--- a/maven/org.eclipse.emf.mwe2.parent/pom.xml
+++ b/maven/org.eclipse.emf.mwe2.parent/pom.xml
@@ -62,6 +62,21 @@
 			<url>http://www.eclipse.org/legal/epl-v10.html</url>
 		</license>
 	</licenses>
+	
+	<pluginRepositories>
+		<!-- for eclipse-jarsigner-plugin -->
+		<pluginRepository>
+			<id>eclipse</id>
+			<url>https://repo.eclipse.org/content/repositories/cbi/</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</pluginRepository>
+	</pluginRepositories>
+	
 	<build>
 		<sourceDirectory>src</sourceDirectory>
 		<plugins>
@@ -243,27 +258,6 @@
 		</pluginManagement>
 	</build>
 	<profiles>
-		<profile>
-			<id>cbi-sign</id>
-			<activation>
-				<property>
-					<name>sign.skip</name>
-					<value>false</value>
-				</property>
-			</activation>
-			<pluginRepositories>
-				<pluginRepository>
-					<id>eclipse</id>
-					<url>https://repo.eclipse.org/content/repositories/cbi/</url>
-					<releases>
-						<enabled>true</enabled>
-					</releases>
-					<snapshots>
-						<enabled>false</enabled>
-					</snapshots>
-				</pluginRepository>
-			</pluginRepositories>
-		</profile>
 		<!-- 
 			Profile 'release' is activated when property BUILD_TYPE is NOT 'N' (nightly).
 			For release builds strict version checking is disabled, since Maven version will be a

--- a/plugins/org.eclipse.emf.mwe.core/pom.xml
+++ b/plugins/org.eclipse.emf.mwe.core/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.emf.mwe.core</artifactId>
-	<version>1.5.0-SNAPSHOT</version>
+	<version>1.5.0</version>
 	<packaging>eclipse-plugin</packaging>
 	<name>org.eclipse.emf.mwe.core</name>
 

--- a/plugins/org.eclipse.emf.mwe.core/pom.xml
+++ b/plugins/org.eclipse.emf.mwe.core/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.emf.mwe.core</artifactId>
-	<version>1.5.0</version>
+	<version>1.5.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 	<name>org.eclipse.emf.mwe.core</name>
 


### PR DESCRIPTION
By default Tycho checks consistency of POM and MANIFEST.MF versions. It is desired to deploy Maven artifacts with Maven final versions, while p2 artifacts should have qualified versions. This requires a mismatch between these artifacts for release builds.

This change adds a `release` profile which disables version checking when `BUILD_TYPE` is not `N`.