### PR TITLE
[#93] Improve formatting of *.mwe2 files.

### DIFF
--- a/plugins/org.eclipse.emf.mwe2.language/src/org/eclipse/emf/mwe2/language/Mwe2RuntimeModule.java
+++ b/plugins/org.eclipse.emf.mwe2.language/src/org/eclipse/emf/mwe2/language/Mwe2RuntimeModule.java
@@ -8,6 +8,7 @@
  *******************************************************************************/
 package org.eclipse.emf.mwe2.language;
 
+import org.eclipse.emf.mwe2.language.formatting.Mwe2Formatter;
 import org.eclipse.emf.mwe2.language.resource.MweLocationInFileProvider;
 import org.eclipse.emf.mwe2.language.resource.MweResourceDescriptionStrategy;
 import org.eclipse.emf.mwe2.language.resource.MweResourceSetProvider;
@@ -17,6 +18,7 @@ import org.eclipse.emf.mwe2.language.scoping.QualifiedNameProvider;
 import org.eclipse.emf.mwe2.language.validation.MweRawSuperTypes;
 import org.eclipse.xtext.common.types.util.RawSuperTypes;
 import org.eclipse.xtext.conversion.IValueConverterService;
+import org.eclipse.xtext.formatting.IFormatter;
 import org.eclipse.xtext.naming.IQualifiedNameProvider;
 import org.eclipse.xtext.resource.IContainer.Manager;
 import org.eclipse.xtext.resource.IDefaultResourceDescriptionStrategy;
@@ -76,5 +78,10 @@ public class Mwe2RuntimeModule extends org.eclipse.emf.mwe2.language.AbstractMwe
 	public Class<? extends RawSuperTypes> bindRawSuperTypes() {
 		return MweRawSuperTypes.class;
 	}
-	
+
+	@Override
+	public Class<? extends IFormatter> bindIFormatter() {
+		return Mwe2Formatter.class;
+	}
+
 }

--- a/tests/org.eclipse.emf.mwe2.language.tests/src/org/eclipse/emf/mwe2/language/tests/formatter/Mwe2FormatterTest.java
+++ b/tests/org.eclipse.emf.mwe2.language.tests/src/org/eclipse/emf/mwe2/language/tests/formatter/Mwe2FormatterTest.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2019 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.emf.mwe2.language.tests.formatter;
+
+import org.eclipse.emf.mwe2.language.Mwe2InjectorProvider;
+import org.eclipse.emf.mwe2.language.mwe2.Module;
+import org.eclipse.xtext.formatting.INodeModelFormatter;
+import org.eclipse.xtext.nodemodel.ICompositeNode;
+import org.eclipse.xtext.resource.XtextResource;
+import org.eclipse.xtext.testing.InjectWith;
+import org.eclipse.xtext.testing.XtextRunner;
+import org.eclipse.xtext.testing.util.ParseHelper;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.google.inject.Inject;
+
+/**
+ * @author miklossy - Initial contribution and API
+ */
+@RunWith(XtextRunner.class)
+@InjectWith(Mwe2InjectorProvider.class)
+public class Mwe2FormatterTest {
+
+	@Inject
+	private ParseHelper<Module> parser;
+
+	@Inject
+	private INodeModelFormatter formatter;
+
+	@Test
+	public void formatting001() {
+		String nl = System.lineSeparator();
+
+		String actual = format("module A Workflow {}");
+
+		String expected = 
+				"module A" + nl +
+				nl +
+				"Workflow {}";
+	
+		Assert.assertEquals(expected, actual);
+	}
+
+	private String format(String unformattedText) {
+		Module module;
+
+		try {
+			module = parser.parse(unformattedText);
+		} catch (Exception e) {
+			e.printStackTrace();
+			return null;
+		}
+
+		XtextResource resource = (XtextResource) module.eResource();
+		ICompositeNode rootNode = resource.getParseResult().getRootNode();
+		return formatter.format(rootNode, 0, unformattedText.length()).getFormattedText();
+	}
+}


### PR DESCRIPTION
- Add corresponding binding of the Mwe2Formatter class in the
Mwe2RuntimeModule .
- Add corresponding Mwe2FormatterTest test cases to ensure that the
custom formatter is worked as desired.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>