### PR TITLE
Bug 550541 - JIRO Migration

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,38 +1,229 @@
-// Tell Jenkins how to build projects from this repository
-node {
-    try {
-        properties([
-            [$class: 'BuildDiscarderProperty', strategy: [$class: 'LogRotator', numToKeepStr: '15']]
-        ])
-        
-        stage 'Checkout'
-        checkout scm
-        
-        dir('build') { deleteDir() }
-        dir('.m2/repository/org/eclipse/emf/mwe') { deleteDir() }
-        dir('.m2/repository/org/eclipse/emf/mwe2') { deleteDir() }
-        
-        stage 'Maven Build'
-        def workspace = pwd()
-        def mvnHome = tool 'M3'
-        env.M2_HOME = "${mvnHome}"
-        try {
-            wrap([$class:'Xvnc', useXauthority: true]) {
-                sh "cd maven; ${mvnHome}/bin/mvn -f org.eclipse.emf.mwe2.parent/pom.xml -Declipse.p2.mirrors=false --batch-mode --update-snapshots -fae -Dmaven.repo.local='${workspace}/.m2/repository' -Dtycho.localArtifacts=ignore clean install javadoc:aggregate-jar; ${mvnHome}/bin/mvn -f org.eclipse.emf.mwe2.parent/pom.xml --batch-mode -fae -Dmaven.repo.local='${workspace}/.m2/repository' -Declipse.p2.mirrors=false -DskipTests -Dtycho.localArtifacts=ignore -DaltDeploymentRepository='local::default::file:${workspace}/build/maven-repo' deploy"
-            }
-        } finally {
-            step([$class: 'JUnitResultArchiver', testResults: '**/target/surefire-reports/*.xml'])
-        }
-        archive 'maven/org.eclipse.emf.mwe2.repository/target/repository/**'
-        archive 'build/**'
-        
-        if (currentBuild.result == 'UNSTABLE') {
-            slackSend color: 'warning', message: "Build Unstable - ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)"
-        } else {
-            slackSend color: 'good', message: "Build Succeeded - ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)"
-        }
-    } catch (e) {
-        slackSend color: 'danger', message: "Build Failed - ${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)"
-        throw e
+pipeline {
+  agent {
+    kubernetes {
+      label 'migration'
     }
+  }
+  
+  parameters {
+    choice(name: 'RELEASE_TYPE', choices: ['Integration', 'Beta', 'M1', 'M2', 'M3', 'RC1', 'RC2', 'GA'], description:
+'''Kind of release to build. The chosen value is dependent on the parameter BUILD_TYPE. Use value:
+<ul>
+  <li><tt>Integration</tt>: Continuous Build</li>
+  <li><tt>GA</tt>: Release Build</li>
+  <li>Any other: Stable/Milestone Build</tt></li>  
+</ul>''')
+    booleanParam(
+      name: 'FORCE_PUBLISH',
+      defaultValue: false, 
+      description: 'Force publishing of build artifacts to Eclipse project storage & OSSRH?'
+    )
+  }
+  
+  triggers {
+    parameterizedCron(env.BRANCH_NAME == 'master' ? '''H H(0-1) * * *''' : '')
+  }
+
+  options {
+    buildDiscarder(logRotator(numToKeepStr:'5'))
+    disableConcurrentBuilds()
+    timeout(time: 60, unit: 'MINUTES')
+    timestamps()
+  }
+
+  environment {
+    PROJECT_STORAGE_PATH = '/home/data/httpd/download.eclipse.org/modeling/emft/mwe'
+    DOWNLOAD_AREA = "$PROJECT_STORAGE_PATH/downloads/drops"
+    KEYRING = credentials('11ef2671-e2bc-4da7-8f89-f4b0ba8ffa3e')
+    SCRIPTS = "$WORKSPACE/git-repo/releng/jenkins/scripts"
+  }
+
+  stages {
+    stage('Prepare') {
+      steps {
+        dir ('git-repo') {
+          checkout scm
+        }
+
+        sh '''
+          # Clean up the build result
+          rm -rf build-result/
+          mkdir -p build-result/downloads/
+          mkdir -p build-result/javadoc/
+          mkdir -p build-result/composite/
+          # Make .mvn/extensions.xml available for the build (for tycho-pomless extension)
+          cp -r git-repo/maven/.mvn .
+
+          # call the versioning script when a release is built
+          # this will set the final release number for Maven artifacts according to RELEASE_TYPE
+          # and disable strict version checking by Tycho, so that p2 artifacts keep their qualifier
+          if [ "$RELEASE_TYPE" != "Integration" ]; then
+            pushd $(pwd) && cd git-repo
+            bash ./set_version.sh --release=$RELEASE_TYPE
+            popd
+          fi
+          
+          gpg --batch --import "${KEYRING}"
+          for fpr in $(gpg --list-keys --with-colons  | awk -F: '/fpr:/ {print $10}' | sort -u);
+          do
+            echo -e "5\ny\n" | gpg --batch --command-fd 0 --expert --edit-key $fpr trust;
+          done
+        '''
+      } // END steps
+    } // END stage
+
+    stage ('Build') {
+      steps {
+        wrap([$class: 'Xvnc', takeScreenshot: false, useXauthority: true]) {
+          withMaven(jdk: 'adoptopenjdk-hotspot-jdk8-latest', maven: 'apache-maven-latest') {
+            dir ('git-repo') {
+              sh ''' 
+                if [ "${BRANCH_NAME}" == "master" ] || [ "${RELEASE_TYPE}" != "Integration" ] || [ "${FORCE_PUBLISH}" == "true" ]; then
+                  GOALS='clean javadoc:aggregate-jar deploy'
+                else
+                  GOALS='clean javadoc:aggregate-jar verify'
+                fi
+                
+                case "$RELEASE_TYPE" in
+                  Integration) BUILD_TYPE='N' ;;
+                  GA) BUILD_TYPE='R' ;;
+                  *) BUILD_TYPE='S' ;;
+                esac
+                
+                mvn \
+                  -f maven/org.eclipse.emf.mwe2.parent/pom.xml \
+                  -Dsign.skip=false \
+                  -DtestFailureIgnore=true \
+                  -Dmaven.javadoc.failOnError=false \
+                  -Dtycho.localArtifacts=ignore \
+                  -DBUILD_TYPE=$BUILD_TYPE \
+                  $GOALS
+              '''
+            }
+          }
+        }
+      } // END steps
+    } // END stage
+
+    stage ('Publish') {
+      when {
+        expression { env.BRANCH_NAME == 'master' || params.RELEASE_TYPE != 'Integration' || params.FORCE_PUBLISH }
+      }
+      steps {
+        sshagent(['projects-storage.eclipse.org-bot-ssh']) {
+          sh '''
+            REPO_SOURCE_DIR=build-result/p2.repository
+            # read properties from promote.properties & publisher.properties
+            VERSION=$($SCRIPTS/get_property.sh build-result/publisher.properties version)
+            BUILD_ID=$($SCRIPTS/get_property.sh build-result/promote.properties build.id)
+            BUILD_TYPE=$($SCRIPTS/get_build_type.sh $BUILD_ID)
+
+            DROP_DIR=$DOWNLOAD_AREA/$VERSION/$BUILD_ID
+
+
+            cp git-repo/maven/org.eclipse.emf.mwe2.repository/target/repository/*.properties build-result/
+            
+            #
+            # STEP 1: Get property values from publisher.properties/promote.properties
+            #
+            # read properties from promote.properties & publisher.properties
+            VERSION=$($SCRIPTS/get_property.sh build-result/publisher.properties version)
+            BUILD_ID=$($SCRIPTS/get_property.sh build-result/promote.properties build.id)
+            BUILD_TYPE=$($SCRIPTS/get_build_type.sh $BUILD_ID)
+            DROP_DIR=$DOWNLOAD_AREA/$VERSION/$BUILD_ID
+            
+            #
+            # STEP 2: move built repository to 'build-result' directory
+            #
+            #cp -R git-repo/maven/org.eclipse.emf.mwe2.parent/target/apidocs/* build-result/javadoc
+            mv git-repo/maven/org.eclipse.emf.mwe2.repository/target/repository build-result/p2.repository
+            mv git-repo/maven/org.eclipse.emf.mwe2.repository/target/emft-mwe-2-lang-Update-$BUILD_ID.zip build-result/downloads/
+
+            case "$BUILD_TYPE" in
+              N) # Nightly
+                REPO_TARGET_DIR=$PROJECT_STORAGE_PATH/updates/nightly
+                ;;
+              S) # Stable
+                REPO_TARGET_DIR=$PROJECT_STORAGE_PATH/updates/milestones/$BUILD_ID
+                ;;
+              R) # Release
+                REPO_TARGET_DIR=$PROJECT_STORAGE_PATH/updates/releases/$VERSION
+                # rename release version: BUILD_ID => VERSION
+                mv build-result/downloads/emft-mwe-2-lang-Update-$BUILD_ID.zip build-result/downloads/emft-mwe-2-lang-Update-$VERSION.zip
+                ;;
+            esac
+            #
+            # STEP 3: make sure p2 repository exists, cleanup and copy repo to there
+            #
+            ssh -x genie.mwe@projects-storage.eclipse.org mkdir -p $REPO_TARGET_DIR
+            ssh -x genie.mwe@projects-storage.eclipse.org rm -rf $REPO_TARGET_DIR/*
+            scp -r $REPO_SOURCE_DIR/* genie.mwe@projects-storage.eclipse.org:$REPO_TARGET_DIR
+
+            #
+            # STEP 4: make sure that drop directory exists, cleanup and copy zipped repo to there
+            #
+            ssh -x genie.mwe@projects-storage.eclipse.org mkdir -p $DROP_DIR
+            ssh -x genie.mwe@projects-storage.eclipse.org rm -rf $DROP_DIR/*
+            scp build-result/downloads/emft-mwe-*.zip genie.mwe@projects-storage.eclipse.org:$DROP_DIR/
+            
+            #
+            # STEP 5: Recreate compositeArtifacts.xml & compositeContent.xml
+            #
+            case "$RELEASE_TYPE" in
+              Integration) ;;
+              GA) # Release
+                ssh genie.mwe@projects-storage.eclipse.org 'cat | /bin/bash /dev/stdin' "releases" < $SCRIPTS/create_composite_update_site.sh ;;
+              *) # Stable
+                ssh genie.mwe@projects-storage.eclipse.org 'cat | /bin/bash /dev/stdin' "milestones" < $SCRIPTS/create_composite_update_site.sh ;;
+            esac
+          '''
+        } // END sshagent
+      } // END steps
+      post {
+        success {
+          archiveArtifacts artifacts: 'build-result/**'
+        }
+      }
+    } // END stage
+  }
+
+  post {
+    always {
+      junit testResults: '**/surefire-reports/*.xml'
+    }
+    cleanup {
+      script {
+        def curResult = currentBuild.currentResult
+        def lastResult = 'NEW'
+        if (currentBuild.previousBuild != null) {
+          lastResult = currentBuild.previousBuild.result
+        }
+
+        if (curResult != 'SUCCESS' || lastResult != 'SUCCESS') {
+          def color = ''
+          switch (curResult) {
+            case 'SUCCESS':
+              color = '#00FF00'
+              break
+            case 'UNSTABLE':
+              color = '#FFFF00'
+              break
+            case 'FAILURE':
+              color = '#FF0000'
+              break
+            default: // e.g. ABORTED
+              color = '#666666'
+          }
+
+          slackSend (
+            message: "${lastResult} => ${curResult}: <${env.BUILD_URL}|${env.JOB_NAME}#${env.BUILD_NUMBER}>",
+            botUser: true,
+            channel: 'xtext-builds',
+            color: "${color}"
+          )
+        }
+      }
+    }
+  }
+
 }

--- a/maven/org.eclipse.emf.mwe2.parent/pom.xml
+++ b/maven/org.eclipse.emf.mwe2.parent/pom.xml
@@ -40,7 +40,7 @@
 		<project.reporting.outputEncoding>ISO-8859-1</project.reporting.outputEncoding>
 
 		<!-- sign.skip = true skips gpg and eclipse signing -->
-		<sign.skip>true</sign.skip>
+		<sign.skip>${sign.skip}</sign.skip>
 		<gpg-skip>${sign.skip}</gpg-skip>
 		<tycho.localArtifacts>ignore</tycho.localArtifacts>
 		<!-- p2-deploy-only = true skips the deploy step -->

--- a/releng/jenkins/scripts/create_composite_update_site.sh
+++ b/releng/jenkins/scripts/create_composite_update_site.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+
+if [ "$1" == "milestones" ]; then
+  REPO_NAME="EMFT MWE Update Site (Milestones)"
+elif [ "$1" == "releases" ]; then
+  REPO_NAME="EMFT MWE Update Site (Releases)"
+else
+  echo "Error: Missing Repository Path!"
+  exit 1
+fi
+
+cd /home/data/httpd/download.eclipse.org/modeling/emft/mwe/updates/$1
+
+TIMESTAMP=$(date +%s000)
+UPDATE_SITES=$(find . -regex '.*/content.\(xml\|jar\|xz\)' -printf "%h\n" | cut -c 3- | sort -u)
+NUMBER_UPDATE_SITES=$(echo "$UPDATE_SITES" | wc -l)
+
+CONTENTXML="<?xml version='1.0' encoding='UTF-8'?>
+<?compositeMetadataRepository version='1.0.0'?>
+<repository name='$REPO_NAME'
+    type='org.eclipse.equinox.internal.p2.metadata.repository.CompositeMetadataRepository'
+    version='1.0.0'>
+  <properties size='1'>
+    <property name='p2.timestamp' value='${TIMESTAMP}'/>
+  </properties>
+  <children size='${NUMBER_UPDATE_SITES}'>
+$(
+for site in $UPDATE_SITES
+do
+printf "    <child location='${site}'/>\n"
+done
+)
+  </children>
+</repository>
+"
+
+echo "$CONTENTXML" > ./compositeContent.xml
+
+ARTIFACTXML="<?xml version='1.0' encoding='UTF-8'?>
+<?compositeArtifactRepository version='1.0.0'?>
+<repository name='${REPO_NAME}'
+    type='org.eclipse.equinox.internal.p2.artifact.repository.CompositeArtifactRepository'
+    version='1.0.0'>
+  <properties size='1'>
+    <property name='p2.timestamp' value='${TIMESTAMP}'/>
+  </properties>
+  <children size='${NUMBER_UPDATE_SITES}'>
+$(
+for site in $UPDATE_SITES
+do
+printf "    <child location='${site}'/>\n"
+done
+)
+  </children>
+</repository>
+"
+
+echo "$ARTIFACTXML" > ./compositeArtifacts.xml

--- a/releng/jenkins/scripts/get_build_type.sh
+++ b/releng/jenkins/scripts/get_build_type.sh
@@ -1,0 +1,21 @@
+#/bin/bash
+
+# Returns BUILD_TYPE based on BUILD_ID
+#
+# $1 BUILD_ID
+#
+# BUILD_TYPE N=Nightly, S=Stable, R=Release
+
+if [ ! "$1" ]; then
+    echo "Error: No BUILD_ID provided" >&2
+    exit 1
+fi
+
+BUILD_TYPE=$(echo $1 |cut -c 1)
+
+if [ ! "$BUILD_TYPE" == "N" ] && [ ! "$BUILD_TYPE" == "S" ] && [ ! "$BUILD_TYPE" == "R" ]; then
+    echo "Invalid BUILD_ID provided" >&2
+    exit 1
+fi
+
+echo $BUILD_TYPE

--- a/releng/jenkins/scripts/get_property.sh
+++ b/releng/jenkins/scripts/get_property.sh
@@ -1,0 +1,15 @@
+#/bin/bash
+
+# $1 path to .properties file
+# $2 property name
+
+if [ ! -f "$1" ]; then
+    echo "File not found: $1" >&2
+    exit 1
+fi
+VALUE=$(grep "^$2" $1 |awk -F= '{print $2}')
+if [ -z "$VALUE" ]; then
+    echo "Could not get property value" >&2
+    exit 1
+fi
+echo $VALUE

--- a/set_version.sh
+++ b/set_version.sh
@@ -78,6 +78,10 @@ if [ "$RELEASE_QUALIFIER" == "N" ]; then
 elif [ "$RELEASE_QUALIFIER" == "GA" ]; then
   MWE2_TO=$MWE2_FROM_BASE
   MWE_TO=$MWE_FROM_BASE
+elif [ "$RELEASE_QUALIFIER" == "Beta" ]; then
+  TS=$(date "+%Y%m%d%H%M")
+  MWE2_TO=$MWE2_FROM_BASE.Beta$TS
+  MWE_TO=$MWE_FROM_BASE.Beta$TS
 else
   MWE2_TO=$(echo "$MWE2_FROM_BASE.$RELEASE_QUALIFIER")
   MWE_TO=$(echo "$MWE_FROM_BASE.$RELEASE_QUALIFIER")
@@ -107,14 +111,21 @@ if [ "$RELEASE_QUALIFIER" == "N" ]; then
   find . -type f -name "pom.xml" | xargs_sed_inplace -e "s/${MWE2_FROM}/${MWE2_TO}-SNAPSHOT/g"
   find . -type f -name "pom.xml" | xargs_sed_inplace -e "s/${MWE_FROM}/${MWE_TO}-SNAPSHOT/g"
 else
-  find . -type f -name "pom.xml" | xargs_sed_inplace -e "s/${MWE2_FROM}/${MWE2_TO}/g"
-  find . -type f -name "pom.xml" | xargs_sed_inplace -e "s/${MWE_FROM}/${MWE_TO}/g"
-  
   if [ "$RELEASE_QUALIFIER" == "GA" ]; then
     sed_inplace -e "s?<BUILD_TYPE>.*</BUILD_TYPE>?<BUILD_TYPE>R</BUILD_TYPE>?" maven/org.eclipse.emf.mwe2.parent/pom.xml
   else
     sed_inplace -e "s?<BUILD_TYPE>.*</BUILD_TYPE>?<BUILD_TYPE>S</BUILD_TYPE>?" maven/org.eclipse.emf.mwe2.parent/pom.xml
   fi
+
+  find . -type f -name "pom.xml" | xargs_sed_inplace -e "s/${MWE2_FROM}/${MWE2_TO}/g"
+  find . -type f -name "pom.xml" | xargs_sed_inplace -e "s/${MWE_FROM}/${MWE_TO}/g"
+  
+  find . -type f -name "MANIFEST.MF" | xargs_sed_inplace -e "s/${MWE2_FROM_BASE}.qualifier/${MWE2_TO}/g"
+  find . -type f -name "MANIFEST.MF" | xargs_sed_inplace -e "s/${MWE_FROM_BASE}.qualifier/${MWE_TO}/g"
+
+  find . -type f -name "feature.xml" | xargs_sed_inplace -e "s/version=\"${MWE2_FROM_BASE}.qualifier\"/version=\"${MWE2_TO}\"/g"
+  find . -type f -name "feature.xml" | xargs_sed_inplace -e "s/version=\"${MWE_FROM_BASE}.qualifier\"/version=\"${MWE_TO}\"/g"
+
 fi
 
 


### PR DESCRIPTION
Jenkinfile:
- Refactor to declarative pipeline
- Use k8s agent 'migration'
- Configure GPG credentials
- Enable publishing to Eclipse download area & OSSRH

Parent POM:
- Configure Eclipse signing dependent on 'sign.skip' parameter. The
signing was always disabled.

Change-Id: I042714bd777825ab18bcea0364234f589245ea2a
Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>