### PR TITLE
Revert pomless build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,8 +53,6 @@ pipeline {
           mkdir -p build-result/downloads/
           mkdir -p build-result/javadoc/
           mkdir -p build-result/composite/
-          # Make .mvn/extensions.xml available for the build (for tycho-pomless extension)
-          cp -r git-repo/maven/.mvn .
 
           # call the versioning script when a release is built
           # this will set the final release number for Maven artifacts according to RELEASE_TYPE

--- a/features/org.eclipse.emf.mwe.doc-feature/pom.xml
+++ b/features/org.eclipse.emf.mwe.doc-feature/pom.xml
@@ -1,0 +1,27 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.eclipse.emf</groupId>
+		<artifactId>org.eclipse.emf.mwe2.features-parent</artifactId>
+		<version>2.11.1-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+	<version>1.5.1-SNAPSHOT</version>
+	<packaging>eclipse-feature</packaging>
+	<artifactId>org.eclipse.emf.mwe.doc.feature</artifactId>
+	<name>${project.artifactId}</name>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho.extras</groupId>
+				<artifactId>tycho-source-feature-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/features/org.eclipse.emf.mwe2.launcher-feature/pom.xml
+++ b/features/org.eclipse.emf.mwe2.launcher-feature/pom.xml
@@ -1,0 +1,14 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.eclipse.emf</groupId>
+		<artifactId>org.eclipse.emf.mwe2.features-parent</artifactId>
+		<version>2.11.1-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+	<packaging>eclipse-feature</packaging>
+	<artifactId>org.eclipse.emf.mwe2.launcher</artifactId>
+	<name>${project.artifactId}</name>
+</project>

--- a/maven/.mvn/extensions.xml
+++ b/maven/.mvn/extensions.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<extensions>
-  <extension>
-    <groupId>org.eclipse.tycho.extras</groupId>
-    <artifactId>tycho-pomless</artifactId>
-    <version>1.3.0</version>
-  </extension>
-</extensions>

--- a/plugins/org.eclipse.emf.mwe.activities/pom.xml
+++ b/plugins/org.eclipse.emf.mwe.activities/pom.xml
@@ -1,0 +1,15 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.eclipse.emf</groupId>
+		<artifactId>org.eclipse.emf.mwe2.plugins-parent</artifactId>
+		<version>2.11.1-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+	<artifactId>org.eclipse.emf.mwe.activities</artifactId>
+	<version>1.5.1-SNAPSHOT</version>
+	<packaging>eclipse-plugin</packaging>
+	<name>${project.artifactId}</name>
+</project>

--- a/plugins/org.eclipse.emf.mwe.doc/pom.xml
+++ b/plugins/org.eclipse.emf.mwe.doc/pom.xml
@@ -1,0 +1,15 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.eclipse.emf</groupId>
+		<artifactId>org.eclipse.emf.mwe2.plugins-parent</artifactId>
+		<version>2.11.1-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+	<artifactId>org.eclipse.emf.mwe.doc</artifactId>
+	<version>1.5.1-SNAPSHOT</version>
+	<packaging>eclipse-plugin</packaging>
+	<name>${project.artifactId}</name>
+</project>

--- a/plugins/org.eclipse.emf.mwe.ui.simpleEditor/pom.xml
+++ b/plugins/org.eclipse.emf.mwe.ui.simpleEditor/pom.xml
@@ -1,0 +1,16 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.eclipse.emf</groupId>
+		<artifactId>org.eclipse.emf.mwe2.plugins-parent</artifactId>
+		<version>2.11.1-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+
+	<artifactId>org.eclipse.emf.mwe.ui.simpleEditor</artifactId>
+	<version>1.5.1-SNAPSHOT</version>
+	<packaging>eclipse-plugin</packaging>
+	<name>${project.artifactId}</name>
+</project>

--- a/plugins/org.eclipse.emf.mwe.ui/pom.xml
+++ b/plugins/org.eclipse.emf.mwe.ui/pom.xml
@@ -1,0 +1,16 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.eclipse.emf</groupId>
+		<artifactId>org.eclipse.emf.mwe2.plugins-parent</artifactId>
+		<version>2.11.1-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+
+	<artifactId>org.eclipse.emf.mwe.ui</artifactId>
+	<version>1.5.1-SNAPSHOT</version>
+	<packaging>eclipse-plugin</packaging>
+	<name>${project.artifactId}</name>
+</project>

--- a/plugins/org.eclipse.emf.mwe2.language.ide/pom.xml
+++ b/plugins/org.eclipse.emf.mwe2.language.ide/pom.xml
@@ -1,0 +1,15 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.eclipse.emf</groupId>
+		<artifactId>org.eclipse.emf.mwe2.plugins-parent</artifactId>
+		<version>2.11.1-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+
+	<artifactId>org.eclipse.emf.mwe2.language.ide</artifactId>
+	<packaging>eclipse-plugin</packaging>
+	<name>${project.artifactId}</name>
+</project>

--- a/plugins/org.eclipse.emf.mwe2.language.ui/pom.xml
+++ b/plugins/org.eclipse.emf.mwe2.language.ui/pom.xml
@@ -1,0 +1,15 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.eclipse.emf</groupId>
+		<artifactId>org.eclipse.emf.mwe2.plugins-parent</artifactId>
+		<version>2.11.1-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+
+	<artifactId>org.eclipse.emf.mwe2.language.ui</artifactId>
+	<packaging>eclipse-plugin</packaging>
+	<name>${project.artifactId}</name>
+</project>

--- a/plugins/org.eclipse.emf.mwe2.launch.ui/pom.xml
+++ b/plugins/org.eclipse.emf.mwe2.launch.ui/pom.xml
@@ -1,0 +1,15 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.eclipse.emf</groupId>
+		<artifactId>org.eclipse.emf.mwe2.plugins-parent</artifactId>
+		<version>2.11.1-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+
+	<artifactId>org.eclipse.emf.mwe2.launch.ui</artifactId>
+	<packaging>eclipse-plugin</packaging>
+	<name>${project.artifactId}</name>
+</project>

--- a/tests/org.eclipse.emf.mwe2.language.tests/pom.xml
+++ b/tests/org.eclipse.emf.mwe2.language.tests/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+	xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.eclipse.emf</groupId>
+		<artifactId>tests-parent</artifactId>
+		<version>2.11.1-SNAPSHOT</version>
+	</parent>
+	<artifactId>org.eclipse.emf.mwe2.language.tests</artifactId>
+	<packaging>eclipse-test-plugin</packaging>
+	<name>${project.artifactId}</name>
+</project>


### PR DESCRIPTION
The pomless build was half-baked. Only a subset of plugins and features
was covered. Either pomless should be done for all possible bundles or
features, or for none.

Change-Id: I8d461323e0bbab55765d57d1c6b9eb5d2a8c1d47
Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>