### PR TITLE
[#120] Add warnings for deprecations.

### DIFF
--- a/plugins/org.eclipse.emf.mwe2.language/src/org/eclipse/emf/mwe2/language/validation/Mwe2Validator.java
+++ b/plugins/org.eclipse.emf.mwe2.language/src/org/eclipse/emf/mwe2/language/validation/Mwe2Validator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008-2011 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2008,2019 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -28,6 +28,7 @@ import org.eclipse.emf.mwe2.language.scoping.FactorySupport;
 import org.eclipse.emf.mwe2.language.scoping.Mwe2ScopeProvider;
 import org.eclipse.emf.mwe2.runtime.Mandatory;
 import org.eclipse.xtext.common.types.JvmAnnotationReference;
+import org.eclipse.xtext.common.types.JvmAnnotationTarget;
 import org.eclipse.xtext.common.types.JvmConstructor;
 import org.eclipse.xtext.common.types.JvmDeclaredType;
 import org.eclipse.xtext.common.types.JvmFeature;
@@ -42,6 +43,7 @@ import org.eclipse.xtext.common.types.JvmTypeReference;
 import org.eclipse.xtext.common.types.JvmVisibility;
 import org.eclipse.xtext.common.types.TypesFactory;
 import org.eclipse.xtext.common.types.TypesPackage;
+import org.eclipse.xtext.common.types.util.DeprecationUtil;
 import org.eclipse.xtext.common.types.util.Primitives;
 import org.eclipse.xtext.common.types.util.RawSuperTypes;
 import org.eclipse.xtext.naming.IQualifiedNameConverter;
@@ -182,6 +184,7 @@ public class Mwe2Validator extends AbstractMwe2Validator {
 
 	public final static String UNUSED_LOCAL = "unused_local_variable";
 	public final static String DUPLICATE_LOCAL = "duplicate_local_variable";
+	public final static String DEPRECATED_ELEMENT = "deprecated_element";
 
 	@Check
 	public void checkReferables(Module referable) {
@@ -399,4 +402,30 @@ public class Mwe2Validator extends AbstractMwe2Validator {
 		return ePackages;
 	}
 
+	@Check
+	public void checkDeprecatedComponent(Component component) {
+		JvmType type = component.getType();
+		if (type instanceof JvmAnnotationTarget && DeprecationUtil.isDeprecated((JvmAnnotationTarget) type)) {
+			warning(
+				"The '" + type.getQualifiedName() + "' is deprecated.",
+				component,
+				Mwe2Package.Literals.REFERRABLE__TYPE,
+				DEPRECATED_ELEMENT);
+		}
+	}
+
+	@Check
+	public void checkDeprecatedAssignment(Assignment assignment) {
+		JvmIdentifiableElement feature = assignment.getFeature();
+		if (feature instanceof JvmOperation) {
+			JvmOperation operation = (JvmOperation) feature;
+			if (DeprecationUtil.isDeprecated(operation)) {
+				warning(
+					"The '" + operation.getQualifiedName() + "' is deprecated.",
+					assignment,
+					Mwe2Package.Literals.ASSIGNMENT__FEATURE,
+					DEPRECATED_ELEMENT);
+			}
+		}
+	}
 }

--- a/tests/org.eclipse.emf.mwe2.language.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.emf.mwe2.language.tests/META-INF/MANIFEST.MF
@@ -21,7 +21,8 @@ Require-Bundle: org.eclipse.emf.mwe2.language,
  org.eclipse.ui.workbench;resolution:=optional,
  org.eclipse.xtext.xbase.lib,
  org.eclipse.xtext.testing,
- org.eclipse.xtext.ui.testing
+ org.eclipse.xtext.ui.testing,
+ org.eclipse.xtext.xtext.generator
 Bundle-ActivationPolicy: lazy
 Import-Package: org.junit;version="4.5.0",
  org.junit.runner;version="4.5.0",

--- a/tests/org.eclipse.emf.mwe2.language.tests/src/org/eclipse/emf/mwe2/language/tests/validation/Mwe2ValidatorTest.java
+++ b/tests/org.eclipse.emf.mwe2.language.tests/src/org/eclipse/emf/mwe2/language/tests/validation/Mwe2ValidatorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008,2010 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2008,2019 itemis AG (http://www.itemis.eu) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -227,7 +227,30 @@ public class Mwe2ValidatorTest {
 		assertEquals(Severity.ERROR, list.get(0).getSeverity());
 		assertTrue(list.get(0).getMessage(), list.get(0).getMessage().contains("foo.bar"));
 	}
-	
+
+	@Test public void testDeprecatedElement() throws Exception {
+		String textModel = 
+			"module m\r\n" + 
+			"\r\n" + 
+			"import org.eclipse.xtext.xtext.generator.XtextGenerator\r\n" + 
+			"import org.eclipse.xtext.xtext.generator.StandardLanguage\r\n" + 
+			"\r\n" + 
+			"Workflow {\r\n" + 
+			"	component = XtextGenerator {\r\n" + 
+			"		language = StandardLanguage {\r\n" + 
+			"			newProjectWizardForEclipse = {}\r\n" + 
+			"		}\r\n" + 
+			"	}\r\n" + 
+			"}";
+		EObject model = getModel(textModel);
+		List<Issue> issues = validate(model);
+		assertEquals(issues.toString(), 1, issues.size());
+		Issue issue = issues.get(0);
+		assertEquals(Mwe2Validator.DEPRECATED_ELEMENT, issue.getCode());
+		assertEquals(Severity.WARNING, issue.getSeverity());
+		assertEquals("The 'org.eclipse.xtext.xtext.generator.StandardLanguage.setNewProjectWizardForEclipse' is deprecated.", issue.getMessage());
+	}
+
 	private List<Issue> validate(EObject model) {
 		XtextResource res = ((XtextResource)model.eResource());
 		List<Issue> list = res.getResourceServiceProvider().getResourceValidator().validate(res, CheckMode.ALL, CancelIndicator.NullImpl);


### PR DESCRIPTION
- Add the checkDeprecatedElements validation check to the Mwe2Validator
to raise warnings if the used component is marked as deprecated.
- Implement corresponding Mwe2ValidatorTest test cases.