### PR TITLE
remove ExecutionEnvironment config nobody knows why it is there

### DIFF
--- a/maven/org.eclipse.emf.mwe2.parent/pom.xml
+++ b/maven/org.eclipse.emf.mwe2.parent/pom.xml
@@ -130,7 +130,6 @@
 							</requirement>
 						</extraRequirements>
 					</dependency-resolution>
-					<executionEnvironment>JavaSE-1.8</executionEnvironment>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
remove ExecutionEnvironment config nobody knows why it is there
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>

@kthoms do you know why the execution environment is there?