### PR TITLE
Don't use [project.version] for dependencies

### DIFF
--- a/plugins/org.eclipse.emf.mwe.core/pom.xml
+++ b/plugins/org.eclipse.emf.mwe.core/pom.xml
@@ -19,7 +19,7 @@
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>
 			<artifactId>org.eclipse.emf.mwe2.runtime</artifactId>
-			<version>[${project.parent.version}]</version>
+			<version>${project.parent.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-cli</groupId>

--- a/plugins/org.eclipse.emf.mwe.utils/pom.xml
+++ b/plugins/org.eclipse.emf.mwe.utils/pom.xml
@@ -19,7 +19,7 @@
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>
 			<artifactId>org.eclipse.emf.mwe.core</artifactId>
-			<version>[${project.version}]</version>
+			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/plugins/org.eclipse.emf.mwe2.language/pom.xml
+++ b/plugins/org.eclipse.emf.mwe2.language/pom.xml
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>
 			<artifactId>org.eclipse.emf.mwe2.runtime</artifactId>
-			<version>[${project.version}]</version>
+			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/plugins/org.eclipse.emf.mwe2.launch/pom.xml
+++ b/plugins/org.eclipse.emf.mwe2.launch/pom.xml
@@ -18,12 +18,12 @@
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>
 			<artifactId>org.eclipse.emf.mwe2.runtime</artifactId>
-			<version>[${project.version}]</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>
 			<artifactId>org.eclipse.emf.mwe2.language</artifactId>
-			<version>[${project.version}]</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.guava</groupId>

--- a/plugins/org.eclipse.emf.mwe2.lib/pom.xml
+++ b/plugins/org.eclipse.emf.mwe2.lib/pom.xml
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>org.eclipse.emf</groupId>
 			<artifactId>org.eclipse.emf.mwe2.runtime</artifactId>
-			<version>[${project.version}]</version>
+			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
I think this might be one of the causes of https://github.com/eclipse/xtext/issues/2664 (see also https://github.com/eclipse/xtext/issues/2229 for further details)