### PR TITLE
Remove unnecessary explicit listing of source units

### DIFF
--- a/maven/org.eclipse.emf.mwe2.target/org.eclipse.emf.mwe2.target.nightly/org.eclipse.emf.mwe2.target.nightly.target
+++ b/maven/org.eclipse.emf.mwe2.target/org.eclipse.emf.mwe2.target.nightly/org.eclipse.emf.mwe2.target.nightly.target
@@ -27,13 +27,9 @@
 <unit id="org.apache.log4j" version="1.2.25"/>
 <unit id="org.junit" version="0.0.0"/>
 <unit id="org.apache.commons.cli" version="1.8.0"/>
-<unit id="org.apache.commons.cli.source" version="1.8.0"/>
 <unit id="org.apache.commons.commons-logging" version="0.0.0"/>
-<unit id="org.apache.commons.commons-logging.source" version="0.0.0"/>
 <unit id="com.google.guava" version="33.2.1.jre"/>
-<unit id="com.google.guava.source" version="33.2.1.jre"/>
 <unit id="com.google.guava.failureaccess" version="1.0.2"/>
-<unit id="com.google.guava.failureaccess.source" version="1.0.2"/>
 <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2024-09"/>
 </location>
 </locations>

--- a/maven/org.eclipse.emf.mwe2.target/org.eclipse.emf.mwe2.target/org.eclipse.emf.mwe2.target.target
+++ b/maven/org.eclipse.emf.mwe2.target/org.eclipse.emf.mwe2.target/org.eclipse.emf.mwe2.target.target
@@ -28,13 +28,9 @@
 <unit id="org.apache.log4j" version="1.2.25"/>
 <unit id="org.junit" version="0.0.0"/>
 <unit id="org.apache.commons.cli" version="1.8.0"/>
-<unit id="org.apache.commons.cli.source" version="1.8.0"/>
 <unit id="org.apache.commons.commons-logging" version="0.0.0"/>
-<unit id="org.apache.commons.commons-logging.source" version="0.0.0"/>
 <unit id="com.google.guava" version="33.2.1.jre"/>
-<unit id="com.google.guava.source" version="33.2.1.jre"/>
 <unit id="com.google.guava.failureaccess" version="1.0.2"/>
-<unit id="com.google.guava.failureaccess.source" version="1.0.2"/>
 <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2024-09"/>
 </location>
 </locations>


### PR DESCRIPTION
The location is configured to include sources. Therefore they don't have to be added explicitly.