### PR TITLE
Clean-up MWE's Feature definition files

### DIFF
--- a/features/org.eclipse.emf.mwe.doc-feature/feature.xml
+++ b/features/org.eclipse.emf.mwe.doc-feature/feature.xml
@@ -31,8 +31,6 @@ SPDX-License-Identifier: EPL-2.0
 
    <plugin
          id="org.eclipse.emf.mwe.doc"
-         download-size="0"
-         install-size="0"
          version="0.0.0"/>
 
 </feature>

--- a/features/org.eclipse.emf.mwe.ui-feature/feature.xml
+++ b/features/org.eclipse.emf.mwe.ui-feature/feature.xml
@@ -47,23 +47,14 @@ SPDX-License-Identifier: EPL-2.0
 
    <plugin
          id="org.eclipse.emf.mwe.ui"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.eclipse.emf.mwe.activities"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.eclipse.emf.mwe.ui.simpleEditor"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
 </feature>

--- a/features/org.eclipse.emf.mwe2.language.sdk-feature/feature.xml
+++ b/features/org.eclipse.emf.mwe2.language.sdk-feature/feature.xml
@@ -32,10 +32,11 @@ SPDX-License-Identifier: EPL-2.0
    <includes
          id="org.eclipse.emf.mwe2.runtime.sdk"
          version="0.0.0"/>
- 
+
    <includes
          id="org.eclipse.emf.mwe2.launcher"
          version="0.0.0"/>
+
    <includes
          id="org.eclipse.emf.mwe2.launcher.source"
          version="0.0.0"/>
@@ -46,56 +47,34 @@ SPDX-License-Identifier: EPL-2.0
 
    <plugin
          id="org.eclipse.emf.mwe2.language"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.eclipse.emf.mwe2.language.ide"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.eclipse.emf.mwe2.language.ui"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.eclipse.emf.mwe2.launch.ui"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
+
    <plugin
          id="org.eclipse.emf.mwe2.language.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.eclipse.emf.mwe2.language.ide.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
+
    <plugin
          id="org.eclipse.emf.mwe2.language.ui.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.eclipse.emf.mwe2.launch.ui.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
 </feature>

--- a/features/org.eclipse.emf.mwe2.launcher-feature/feature.xml
+++ b/features/org.eclipse.emf.mwe2.launcher-feature/feature.xml
@@ -4,7 +4,7 @@
       label="%featureName"
       version="2.21.0.qualifier"
       provider-name="%providerName"
-	  license-feature="org.eclipse.license"
+      license-feature="org.eclipse.license"
       license-feature-version="0.0.0">
 
    <description>
@@ -46,9 +46,6 @@ SPDX-License-Identifier: EPL-2.0
 
    <plugin
          id="org.eclipse.emf.mwe2.launch"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
 </feature>

--- a/features/org.eclipse.emf.mwe2.runtime.sdk-feature/feature.xml
+++ b/features/org.eclipse.emf.mwe2.runtime.sdk-feature/feature.xml
@@ -36,29 +36,18 @@ SPDX-License-Identifier: EPL-2.0
 
    <plugin
          id="org.eclipse.emf.mwe2.runtime"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.eclipse.emf.mwe2.lib"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
+
    <plugin
          id="org.eclipse.emf.mwe2.runtime.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.eclipse.emf.mwe2.lib.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
 </feature>


### PR DESCRIPTION
Rewrite all feature.xml files through the PDE Feature Editor and let it clean them it up.

The removed attributes are unnecessary/unused for some time and the PDE Feature editor recently has been updated to remove these attributes.