### PR TITLE
[Build] Set compiler's --release option instead of --source and --target

### DIFF
--- a/maven/org.eclipse.emf.mwe2.parent/pom.xml
+++ b/maven/org.eclipse.emf.mwe2.parent/pom.xml
@@ -6,7 +6,6 @@
 	<packaging>pom</packaging>
 	<name>org.eclipse.emf.mwe2.parent</name>
 
-
 	<distributionManagement>
 		<snapshotRepository>
 			<id>ossrh</id>
@@ -24,8 +23,7 @@
 		<tycho-qualifier>yyyyMMdd-HHmm</tycho-qualifier>
 		
 		<tycho-version>4.0.10</tycho-version>
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>
+		<maven.compiler.release>17</maven.compiler.release>
 		<maven-install-version>2.5.2</maven-install-version>
 		<maven-deploy-version>2.8.2</maven-deploy-version>
 		<maven-javadoc-version>3.4.1</maven-javadoc-version>
@@ -212,7 +210,7 @@
 								<name>model</name>
 								<placement>X</placement>
 							</tag>
-						</tags>	
+						</tags>
 					</configuration>
 				</plugin>
 				<plugin>


### PR DESCRIPTION
The release option is simpler to use (just one option) and more powerful, it also checks if the Java standard API referenced is available in the specified release.

This is extracted from
- https://github.com/eclipse/mwe/pull/301